### PR TITLE
Add support for imported targets

### DIFF
--- a/FindFortran.cmake
+++ b/FindFortran.cmake
@@ -30,6 +30,11 @@ These variables may be set to choose which compiler executable is looked up.
   is not in the ``PATH``, this variable may be set to ensure it is
   discovered.
 
+.. variable:: Fortran_IMPORTED_TARGET_NAMESPACE
+
+  This variable may be set to add imported targets for each implicit
+  link libraries and define  the :variable:`<Fortran_IMPORTED_TARGET_NAMESPACE>_Fortran_<Fortran_COMPILER_ID>_SUPPORT_LIBRARIES`.
+
 
 The module may be used multiple times to find different compilers.
 
@@ -77,6 +82,20 @@ This module will set the following variables in your project:
   List of directories corresponding to :variable:`Fortran_<Fortran_COMPILER_ID>_RUNTIME_LIBRARIES`.
 
   This list of directories may be used to configure a launcher.
+
+.. variable:: <Fortran_IMPORTED_TARGET_NAMESPACE>_Fortran_<Fortran_COMPILER_ID>_SUPPORT_LIBRARIES
+
+  This variable may be set to the list of :variable:`<Fortran_IMPORTED_TARGET_NAMESPACE>::Fortran_<Fortran_COMPILER_ID>_<IMPLICIT_LIBRARY_NAME>`.
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+.. variable:: <Fortran_IMPORTED_TARGET_NAMESPACE>::Fortran_<Fortran_COMPILER_ID>_<IMPLICIT_LIBRARY_NAME>
+
+  If :variable:`Fortran_IMPORTED_TARGET_NAMESPACE` is set, this module defines :prop_tgt:`IMPORTED` targets
+  for each implicit link libraries. Each target is named following the pattern
+  ``<Fortran_IMPORTED_TARGET_NAMESPACE>::Fortran_<Fortran_COMPILER_ID>_<IMPLICIT_LIBRARY_NAME>``
+  OpenCL has been found.
 
 #]=======================================================================]
 
@@ -394,6 +413,26 @@ if(Fortran_${_id}_IMPLICIT_LINK_LIBRARIES)
 endif()
 if(Fortran_${_id}_RUNTIME_LIBRARIES)
   list(APPEND _additional_required_vars Fortran_${_id}_RUNTIME_DIRECTORIES)
+endif()
+
+# imported targets
+if(Fortran_IMPORTED_TARGET_NAMESPACE)
+  set(_imported_targets)
+  if(Fortran_${_id}_IMPLICIT_LINK_LIBRARIES)
+    set(_link_libs ${Fortran_${_id}_IMPLICIT_LINK_LIBRARIES})
+    list(REMOVE_ITEM _link_libs c crypt dl gcc_s m nsl rt util pthread stdc++)
+    foreach(_lib IN LISTS _link_libs)
+      find_library(Fortran_${_id}_${_lib}_IMPLICIT_LINK_LIBRARY ${_lib} PATHS ${Fortran_${_id}_IMPLICIT_LINK_DIRECTORIES})
+
+      add_library(${Fortran_IMPORTED_TARGET_NAMESPACE}::Fortran_${_id}_${_lib} UNKNOWN IMPORTED)
+      set_target_properties(${Fortran_IMPORTED_TARGET_NAMESPACE}::Fortran_${_id}_${_lib} PROPERTIES
+        IMPORTED_LOCATION "${Fortran_${_id}_${_lib}_IMPLICIT_LINK_LIBRARY}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        )
+      list(APPEND _imported_targets ${Fortran_IMPORTED_TARGET_NAMESPACE}::Fortran_${_id}_${_lib})
+    endforeach()
+  endif()
+  set(${Fortran_IMPORTED_TARGET_NAMESPACE}_Fortran_${_id}_SUPPORT_LIBRARIES ${_imported_targets})
 endif()
 
 # outputs


### PR DESCRIPTION
* [ ] Add CMake property target for disabling the use of `CMAKE_<Lang>_IMPLICIT_LINK_*` variables. 

This is relevant when the project enables Fortran language and its `CMake_Fortran_COMPILER_ID` is different from the one of targets imported via `find_package(Foo)`

Explicitly updating the `Foo` targets setting `IMPLICIT_LINK_<LANG>_ENABLED` to `0` will ensure only the `<Fortran_IMPORTED_TARGET_NAMESPACE>_Fortran_<Fortran_COMPILER_ID>_SUPPORT_LIBRARIES` are linked.

Within  property like `IMPLICIT_LINK_Fortran_ENABLED`, it looks like the same effect can be achieved removing Fortran from the `IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE` properties but this cumbersome:

```
set_target_properties(blas PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "")
set_target_properties(lapack PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "")
```


Ideally the `foo-config.cmake.in` would look like this:

```
[...]

include("${_Foo_SELF_DIR}/foo-targets.cmake")

# Hint for project building against Foo
set(Foo_Fortran_COMPILER_ID "@CMAKE_Fortran_COMPILER_ID@")

if("SupportLibraries" IN_LIST Foo_FIND_COMPONENTS)
  include(CMakeFindDependencyMacro)

  set(Fortran_COMPILER_ID ${Foo_Fortran_COMPILER_ID})
  set(Fortran_IMPORTED_TARGET_NAMESPACE "Foo")

  find_dependency(Fortran)

  target_link_libraries(Foo INTERFACE  ${Foo_Fortran_${Foo_Fortran_COMPILER_ID}_SUPPORT_LIBRARIES})

  set_target_properties(${Fortran_IMPORTED_TARGET_NAMESPACE}::Fortran_${_id}_${_lib} 
    PROPERTIES IMPLICIT_LINK_ENABLED 0)

  # cleanup
  unset(Fortran_COMPILER_ID)
  unset(Fortran_IMPORTED_TARGET_NAMESPACE)
endif()
```
